### PR TITLE
added chunk server ping, moved server url to env/config, fixed upload/download to use multiple chunk servers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+SHELL := /bin/bash
+PROJECT_DIR = $(shell pwd)
+
+start-ms:
+	ROCKET_PORT=8080 cargo run --manifest-path ./metadata-server/Cargo.toml
+
+start-cs:
+	METADATA_URL=http://localhost:8080 cargo run --manifest-path ./chunk-server/Cargo.toml
+
+ccfs-cli:
+	cargo run --manifest-path ./cli/Cargo.toml

--- a/chunk-server/src/main.rs
+++ b/chunk-server/src/main.rs
@@ -18,17 +18,16 @@ use rocket::response::Stream;
 use rocket::Data;
 use rocket_contrib::json::JsonValue;
 use rocket_contrib::uuid::Uuid as UuidRC;
+use rocket_multipart_form_data::{
+  MultipartFormData, MultipartFormDataField, MultipartFormDataOptions,
+  RawField, TextField,
+};
 use std::collections::HashMap;
 use std::env;
 use std::fs::{self, File};
 use std::path::PathBuf;
 use std::{thread, time};
 use uuid::Uuid;
-
-use rocket_multipart_form_data::{
-  MultipartFormData, MultipartFormDataField, MultipartFormDataOptions,
-  RawField, TextField,
-};
 
 const METADATA_URL_KEY: &str = "METADATA_URL";
 const SERVER_ADDRESS_KEY: &str = "SERVER_ADDRESS";
@@ -135,7 +134,6 @@ fn multipart_upload(content_type: &ContentType, data: Data) -> JsonValue {
 fn download(chunk_id: UuidRC) -> Option<Stream<File>> {
   let mut file_path = UPLOADS_DIR.to_path_buf();
   file_path.push(chunk_id.to_string());
-  println!("{}", file_path.as_path().to_str().unwrap().to_string());
   File::open(file_path).map(|file| Stream::from(file)).ok()
 }
 
@@ -159,8 +157,7 @@ fn start_ping_job(address: String) {
       )
       .header("x-chunk-server-id", ID.to_string())
       .header("x-chunk-server-address", &address)
-      .send()
-      .unwrap();
+      .send();
     thread::sleep(time::Duration::from_millis(5000))
   });
 }
@@ -182,7 +179,6 @@ fn main() {
         rocket_instance.config().address,
         rocket_instance.config().port
       );
-      println!("starting ping");
       start_ping_job(server_addr);
 
       rocket_instance.launch();

--- a/chunk-server/src/main.rs
+++ b/chunk-server/src/main.rs
@@ -19,14 +19,19 @@ use rocket::Data;
 use rocket_contrib::json::JsonValue;
 use rocket_contrib::uuid::Uuid as UuidRC;
 use std::collections::HashMap;
+use std::env;
 use std::fs::{self, File};
 use std::path::PathBuf;
+use std::{thread, time};
 use uuid::Uuid;
 
 use rocket_multipart_form_data::{
   MultipartFormData, MultipartFormDataField, MultipartFormDataOptions,
   RawField, TextField,
 };
+
+const METADATA_URL_KEY: &str = "METADATA_URL";
+const SERVER_ADDRESS_KEY: &str = "SERVER_ADDRESS";
 
 lazy_static! {
     // should be replaced with DB
@@ -59,9 +64,6 @@ fn multipart_upload(content_type: &ContentType, data: Data) -> JsonValue {
   let multipart_form_data =
     MultipartFormData::parse(content_type, data, options).unwrap();
 
-  // The file will be delete automatically when the MultipartFormData instance
-  // is dropped. If you want to handle that file by your own, instead of
-  // killing it, just remove it out from the MultipartFormData instance.
   let file = multipart_form_data.raw.get("file");
   let file_id_text = multipart_form_data.texts.get("file_id");
   let file_part_num_text = multipart_form_data.texts.get("file_part_num");
@@ -115,10 +117,13 @@ fn multipart_upload(content_type: &ContentType, data: Data) -> JsonValue {
     }
   }
 
-  println!("{}", &chunk.id);
+  let metadata_server_url = env::var(METADATA_URL_KEY).unwrap();
   let _resp = reqwest::Client::new()
     .post(
-      reqwest::Url::parse("http://localhost:8080/api/chunk/completed").unwrap(),
+      reqwest::Url::parse(
+        format!("{}/api/chunk/completed", metadata_server_url).as_str(),
+      )
+      .unwrap(),
     )
     .json(&chunk)
     .send()
@@ -142,6 +147,24 @@ fn not_found() -> JsonValue {
   })
 }
 
+fn start_ping_job(address: String) {
+  thread::spawn(move || loop {
+    let metadata_server_url = env::var(METADATA_URL_KEY).unwrap();
+    let _resp = reqwest::Client::new()
+      .post(
+        reqwest::Url::parse(
+          format!("{}/api/ping", metadata_server_url).as_str(),
+        )
+        .unwrap(),
+      )
+      .header("x-chunk-server-id", ID.to_string())
+      .header("x-chunk-server-address", &address)
+      .send()
+      .unwrap();
+    thread::sleep(time::Duration::from_millis(5000))
+  });
+}
+
 fn rocket() -> rocket::Rocket {
   rocket::ignite()
     .mount("/api", routes![multipart_upload, download])
@@ -151,5 +174,21 @@ fn rocket() -> rocket::Rocket {
 fn main() {
   CHUNKS.set(HashMap::new()).unwrap();
 
-  rocket().launch();
+  match env::var(METADATA_URL_KEY) {
+    Ok(_) => {
+      let rocket_instance = rocket();
+      let server_addr = format!(
+        "http://{}:{}",
+        rocket_instance.config().address,
+        rocket_instance.config().port
+      );
+      println!("starting ping");
+      start_ping_job(server_addr);
+
+      rocket_instance.launch();
+    }
+    Err(_) => {
+      println!("missing {} env variable", METADATA_URL_KEY);
+    }
+  }
 }

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -151,6 +151,7 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -573,6 +574,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "libc"
 version = "0.2.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1225,6 +1231,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,6 +1655,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "yaml-rust"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "yansi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,6 +1736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
+"checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
@@ -1781,6 +1807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
 "checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
+"checksum serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)" = "691b17f19fc1ec9d94ec0b5864859290dff279dbd7b03f017afda54eb36c3c35"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7345c971d1ef21ffdbd103a75990a15eb03604fc8b8852ca8cb418ee1a099028"
@@ -1832,5 +1859,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+"checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
 "checksum yansi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d60c3b48c9cdec42fb06b3b84b5b087405e1fa1c644a1af3930e4dfafe93de48"
 "checksum yansi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,6 +11,7 @@ uuid = { version = "0.7", features = ["v4"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_derive = "1.0"
+serde_yaml = "0.8"
 clap="2.33"
 reqwest = "0.9"
 ccfs-commons = {path = "../ccfs-commons"}

--- a/cli/cli_config.yaml
+++ b/cli/cli_config.yaml
@@ -1,0 +1,3 @@
+## CCFS cli config file
+
+metadata-server-url: http://localhost:8080

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,9 +4,10 @@ extern crate ccfs_commons;
 extern crate clap;
 extern crate reqwest;
 
-use ccfs_commons::{Chunk, File, FileStatus, CHUNK_SIZE};
+use ccfs_commons::{Chunk, ChunkServer, File, FileStatus, CHUNK_SIZE};
 use clap::{App, Arg, SubCommand};
 use reqwest::multipart::Part;
+use std::collections::HashMap;
 use std::fs::File as FileFS;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
@@ -18,6 +19,15 @@ fn main() {
     .version("1.0")
     .author("Zoran L. <lazarevic.zoki91@gmail.com>")
     .about("A distrubuted highly available file system")
+    .arg(
+      Arg::with_name("config")
+        .short("c")
+        .long("config")
+        .value_name("FILE")
+        .help("Sets a custom config file")
+        .default_value("./cli_config.yaml")
+        .takes_value(true),
+    )
     .subcommand(
       SubCommand::with_name("upload")
         .about("upload a file to the CCFS")
@@ -53,11 +63,30 @@ fn main() {
         ),
     )
     .get_matches();
+
+  let config_file_path = matches.value_of("config").unwrap_or_default();
+  let path = Path::new(config_file_path);
+  if !path.exists() {
+    println!("{} file doesn't exists", config_file_path)
+  }
+  if path.is_dir() {
+    println!("{} is a directory", config_file_path)
+  }
+
+  let config_file = std::fs::File::open(path).unwrap();
+  let config_map: HashMap<String, String> =
+    serde_yaml::from_reader(config_file).unwrap();
+  let meta_server_url = config_map.get("metadata-server-url").unwrap();
+  println!("{:?}", meta_server_url);
   let client = reqwest::Client::new();
 
   if let Some(ref matches) = matches.subcommand_matches("upload") {
     println!("matches {:?}", matches.value_of("file_path"));
-    upload(client, matches.value_of("file_path").unwrap())
+    upload(
+      &meta_server_url,
+      client,
+      matches.value_of("file_path").unwrap(),
+    )
   } else if let Some(ref matches) = matches.subcommand_matches("download") {
     let file_id = matches.value_of("file_id").unwrap();
     let mut path_buf = PathBuf::new();
@@ -75,7 +104,7 @@ fn main() {
       path_buf.push(file_id);
       path = path_buf.as_path();
     }
-    download(client, file_id, path)
+    download(&meta_server_url, client, file_id, path)
   } else if let Some(ref _matches) = matches.subcommand_matches("remove") {
     println!("Not implemented yet :(")
   } else {
@@ -83,73 +112,90 @@ fn main() {
   }
 }
 
-fn upload(client: reqwest::Client, path: &str) {
+fn upload(meta_server_url: &str, client: reqwest::Client, path: &str) {
   let file_path = Path::new(path);
   println!("upload");
   if file_path.exists() {
     let size = file_path.metadata().unwrap().len();
     let file_data = File {
       id: Uuid::nil(),
+      name: file_path.to_str().unwrap().to_string(),
       size,
       num_of_chunks: 0,
       num_of_completed_chunks: 0,
       status: FileStatus::Started,
     };
     let file_resp: Result<File, _> = client
-      .post("http://localhost:8080/api/files/upload")
+      .post(format!("{}/api/files/upload", meta_server_url).as_str())
       .json(&file_data)
       .send()
       .unwrap()
       .json();
-    // let mut servers = client.get("http://localhost:8080/api/servers");
+    let servers_resp: Result<Vec<ChunkServer>, _> = client
+      .get(format!("{}/api/servers", meta_server_url).as_str())
+      .send()
+      .unwrap()
+      .json();
+    println!("{:?}", servers_resp);
+    if !servers_resp.is_ok() {
+      return println!("There are no available servers at the moment");
+    } else {
+      match file_resp {
+        Ok(file) => {
+          println!("file id: {}", file.id);
+          let servers = servers_resp.unwrap();
+          let mut i = 0;
+          let mut file_part = 1;
+          let mut f = FileFS::open(file_path).unwrap();
 
-    match file_resp {
-      Ok(file) => {
-        println!("file id: {}", file.id);
-        let mut file_part = 1;
-        let mut f = FileFS::open(file_path).unwrap();
+          loop {
+            let mut chunk = Vec::with_capacity(CHUNK_SIZE as usize);
+            let n = std::io::Read::by_ref(&mut f)
+              .take(CHUNK_SIZE)
+              .read_to_end(&mut chunk)
+              .unwrap();
+            if n == 0 {
+              break;
+            }
+            let form = reqwest::multipart::Form::new()
+              .text("file_id", file.id.to_string())
+              .text("file_part_num", file_part.to_string())
+              .part("file", Part::bytes(chunk));
+            let server = &servers[i];
+            i = i + 1;
+            client
+              .post(format!("{}/api/upload", server.address).as_str())
+              .multipart(form)
+              .send()
+              .unwrap();
 
-        loop {
-          let mut chunk = Vec::with_capacity(CHUNK_SIZE as usize);
-          let n = std::io::Read::by_ref(&mut f)
-            .take(CHUNK_SIZE)
-            .read_to_end(&mut chunk)
-            .unwrap();
-          if n == 0 {
-            break;
+            file_part = file_part + 1;
+
+            if n < CHUNK_SIZE as usize {
+              break;
+            }
           }
-          // select random server and upload chunk
-          let form = reqwest::multipart::Form::new()
-            .text("file_id", file.id.to_string())
-            .text("file_part_num", file_part.to_string())
-            .part("file", Part::bytes(chunk));
-          client
-            .post("http://localhost:8000/api/upload")
-            .multipart(form)
-            .send()
-            .unwrap();
-
-          file_part = file_part + 1;
-
-          if n < CHUNK_SIZE as usize {
-            break;
-          }
+          println!("Completed file upload");
         }
-        println!("Completed file upload");
+        _ => println!("Error while uploading file"),
       }
-      _ => println!("Error while uploading file"),
     }
   } else {
     println!("The file {} doesn't exists", path);
   }
 }
 
-fn download(client: reqwest::Client, file_id: &str, path: &Path) {
+fn download(
+  meta_server_url: &str,
+  client: reqwest::Client,
+  file_id: &str,
+  path: &Path,
+) {
   // get chunks and merge them into a file
   let file_resp: Result<File, _> = client
     .get(
       reqwest::Url::parse(
-        format!("http://localhost:8080/api/files/{}", &file_id).as_str(),
+        format!("{}/api/files/{}", meta_server_url, &file_id).as_str(),
       )
       .unwrap(),
     )
@@ -161,8 +207,7 @@ fn download(client: reqwest::Client, file_id: &str, path: &Path) {
     let chunks_resp: Result<Vec<Chunk>, _> = client
       .get(
         reqwest::Url::parse(
-          format!("http://localhost:8080/api/chunks/file/{}", &file.id)
-            .as_str(),
+          format!("{}/api/chunks/file/{}", meta_server_url, &file.id).as_str(),
         )
         .unwrap(),
       )
@@ -174,20 +219,35 @@ fn download(client: reqwest::Client, file_id: &str, path: &Path) {
       chunks.sort_by(|a, b| a.file_part_num.cmp(&b.file_part_num));
       let mut file = FileFS::create(path).unwrap();
       for chunk in chunks.iter() {
-        let mut resp = client
+        let server_resp: Result<ChunkServer, _> = client
           .get(
             reqwest::Url::parse(
-              format!("http://localhost:8000/api/download/{}", &chunk.id)
+              format!("{}/api/servers/{}", meta_server_url, &chunk.server_id)
                 .as_str(),
             )
             .unwrap(),
           )
           .send()
-          .unwrap();
-        println!("{:?}", resp);
-        let mut buf: Vec<u8> = vec![];
-        resp.copy_to(&mut buf).unwrap();
-        file.write(&buf).unwrap();
+          .unwrap()
+          .json();
+        if !server_resp.is_ok() {
+          println!("Cannot find server {}", &chunk.server_id);
+        } else {
+          let server = server_resp.unwrap();
+          let mut resp = client
+            .get(
+              reqwest::Url::parse(
+                format!("{}/api/download/{}", server.address, &chunk.id)
+                  .as_str(),
+              )
+              .unwrap(),
+            )
+            .send()
+            .unwrap();
+          let mut buf: Vec<u8> = vec![];
+          resp.copy_to(&mut buf).unwrap();
+          file.write(&buf).unwrap();
+        }
       }
     }
   }


### PR DESCRIPTION
This PR includes the following changes:

- implemented chunk server to ping metadata server (with chunk server data - id and address) to notify meta server that it is available
- removed hardcoded urls, using  env variable and config file instead
- fixed cli upload/download to use chunk server from the list of available servers