### PR TITLE
include branch name in rebuild script

### DIFF
--- a/rebuild-dev.sh
+++ b/rebuild-dev.sh
@@ -1,24 +1,26 @@
-#!/bin/sh
+#!/bin/bash
 PROJECT_DIR=$(pwd)
 STATE_FILE="$PROJECT_DIR/.repo_state"
 
 ARGS=( "$@" )
 
-function run_build() {
-    git stash create > $STATE_FILE
-    docker-compose build $1
+function get_branch() {
+    git status|grep -E 'On branch .*'|sed 's/On branch //'
 }
 
-if [ -f "$STATE_FILE" ]; then
+function run_build() {
+    docker-compose build && {
+        git stash create > $STATE_FILE
+        get_branch >> $STATE_FILE
+    } || echo "build failed" > $STATE_FILE
+}
+
+if [ -f "$STATE_FILE" ] && [ "$(awk 'NR==1' $STATE_FILE)" != "build failed" ]; then
+    CHANGED_BRANCH=$(diff <(echo "$(awk 'NR==2' $STATE_FILE)") <(echo "$(get_branch)"))
     if [ ${#ARGS[@]} -eq 0 ]; then
-        CHANGED=$(git diff $(cat .repo_state) --name-only|grep -E '.*(\.rs$|.*Dockerfile.dev$)')
-        if [ ! -z "$CHANGED" ]; then
+        CHANGED_FILES=$(git diff $(awk 'NR==1' $STATE_FILE) --name-only|grep -E '.*(\.rs$|.*Dockerfile.dev$)')
+        if [ ! -z "$CHANGED_BRANCH" ] || [ ! -z "$CHANGED_FILES" ]; then
             run_build
-        fi
-    else
-        CHANGED=$(git diff $(cat .repo_state) --name-only|grep -E "$1\/.*(\.rs$|.*Dockerfile.dev$)")
-        if [ ! -z "$CHANGED" ]; then
-            run_build $1
         fi
     fi
 else


### PR DESCRIPTION
Improve rebuild script to check if the branch name changes since the last build.
Also handling the case when the build is stoped/failed (some images may succeed, which would make the bin versions inconsistent), by forcing rebuild.